### PR TITLE
Use Django Caching

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-v0.2.3, 11/11/2014 -- Respect ignored paths even when already cached.
+Unreleased -- Use Django's cache middleware to differentiate between page headers.
+v0.2.3x11/11/2014 -- Respect ignored paths even when already cached.
 v0.2.2, 12/10/2014 -- Improved internals description in README. Added debug logging.
 v0.2.0, 09/02/2013 -- Don't differentiate between page headers when caching.
 v0.1.1, 07/20/2013 -- Added safety check for invalidation middleware.


### PR DESCRIPTION
The current behavior of caching only based on the path and HTTP method is not able to have different caches based on other headers.

We need to find a way to respect [vary headers](https://docs.djangoproject.com/en/dev/topics/cache/#using-vary-headers), as cache middleware does (as per #14)

The first step is choosing a data format for the cache. By this I mean, how should the cache keys and values be structured? Django's cache middleware implementation is undocumented, but can be determined by their [middleware code](https://github.com/django/django/blob/master/django/middleware/cache.py).

Our current caching structure is very simple. If shown as if the Django cache was a dictionary, it would look like this:

``` python
{
    'dumper.cached_path.{path_hash}.{method}': <Response object>,
    'dumper.cached_path.{path_hash}.{method}': <Response object>,
    ...
}
```

With this setup, invalidation is very easy. Just delete all possible keys from the path hash and all possible method names.

To figure out the best way to implement invalidating Django's cache we need to explain it in the same way. Note that cache keys can not be invalidated by regex's. They also can not be listed. The only way to delete a key is to use it's key name. 

The old django-dumper implements it this way. The code for the old site is [here](https://github.com/saulshanabrook/django-dumper/blob/v0.1.1/dumper/middleware.py)
